### PR TITLE
Update XSFPlayer_2SF.cpp

### DIFF
--- a/src/in_2sf/XSFPlayer_2SF.cpp
+++ b/src/in_2sf/XSFPlayer_2SF.cpp
@@ -211,7 +211,8 @@ bool XSFPlayer_2SF::Load()
 	if (NDS_Init())
 		return false;
 
-	SPU_ChangeSoundCore(SNDIFID_2SF, 737);
+	static const int BUFFERSIZE = DESMUME_SAMPLE_RATE / 59.837; //truncates to 737, the traditional value, for 44100
+	SPU_ChangeSoundCore(SNDIFID_2SF, BUFFERSIZE);
 
 	execute = false;
 


### PR DESCRIPTION
Make it substantially more obvious how to hack the 2sf player to output at a different samplerate by removing the secret implicit 44100 based calculation