### PR TITLE
NCSF: Fix pitch bend effect on some songs

### DIFF
--- a/src/in_ncsf/SSEQPlayer/Track.cpp
+++ b/src/in_ncsf/SSEQPlayer/Track.cpp
@@ -695,7 +695,6 @@ void Track::Run()
 
 				case SSEQCommand::PortamentoTime:
 					this->portaTime = this->overriding.val<std::uint8_t>(pData, read8);
-					this->state.set(ConvertFuncs::ToIntegral(TrackState::PortamentoBit));
 					// Update here?
 					break;
 


### PR DESCRIPTION
Since part of this [commit](https://github.com/CyberBotX/in_xsf/commit/3f890b6899b6c5ff871efa42cec352da65761621) creates a pitch bend effect with some instruments in certain conditions, specifically at PortamentoTime, the line in question is now removed after initial tests. Further testing with more NCSF rips over time confirms no other issues. Fixes issue https://github.com/CyberBotX/in_xsf/issues/7.